### PR TITLE
Remove standard library packages from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,6 @@ dependencies = [
     "soundfile",
     "sounddevice",
     "pandas",
-    "sys",
-    "os",
-    "pickle",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`sys`, `os`, and `pickle` are part of the Python standard libraries and hence are automatically available when installing Python. They do not need to be installed separately.