### PR TITLE
Constrain gh documentation action to python 3.10

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install sphinx sphinx_rtd_theme myst_parser


### PR DESCRIPTION
The current requirements (numpy <2.0) fail to resolve for Python 3.13 which does not support old numpy versions.