### PR TITLE
Add installing documentation dependencies through pyproject.toml

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -12,7 +12,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install sphinx sphinx_rtd_theme myst_parser
+          pip install -e ".[docs]"
       - name: Sphinx build
         run: |
           sphinx-build doc _build


### PR DESCRIPTION
Use the optional [docs] section of the pyproject.toml to install the documentation build dependencies.